### PR TITLE
Fix GitHub actions build and release workflow

### DIFF
--- a/.github/workflows/python-build-release.yml
+++ b/.github/workflows/python-build-release.yml
@@ -38,7 +38,6 @@ jobs:
           else
             pyinstaller --add-data "src/data/resources:resources" --icon "src/data/resources/assets/icon.png" --paths src src/main.py --name CarbonCalculator
           fi
-        continue-on-error: true
       # Archive the build artifacts
       - run: |
           mkdir -p build
@@ -56,18 +55,26 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # Check for successful build completion
+      - name: Check build status
+        if: ${{ always() }}
+        run: |
+          if [ -z "$(ls -A build)" ]; then
+            echo "Build failed, no artifacts found."
+            exit 1
+          fi
       # Download the build artifacts for each OS
       - uses: actions/download-artifact@v4
         with:
-          name: CarbonCalculator-ubuntu-${{ github.ref }}
+          name: CarbonCalculator-ubuntu-latest
           path: build/linux
       - uses: actions/download-artifact@v4
         with:
-          name: CarbonCalculator-macos-${{ github.ref }}
+          name: CarbonCalculator-macos-latest
           path: build/macos
       - uses: actions/download-artifact@v4
         with:
-          name: CarbonCalculator-windows-${{ github.ref }}
+          name: CarbonCalculator-windows-latest
           path: build/windows
       # Create a new release
       - id: create_release

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License](https://img.shields.io/github/license/Luis-Rosario-Alers/CarbonCalculator)](https://github.com/Luis-Rosario-Alers/CarbonCalculator/blob/master/LICENSE)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![codecov](https://codecov.io/github/Luis-Rosario-Alers/CarbonCalculator/graph/badge.svg?token=OVPU0O07GO)](https://codecov.io/github/Luis-Rosario-Alers/CarbonCalculator)
+[![Build and Release](https://github.com/Luis-Rosario-Alers/CarbonCalculator/actions/workflows/python-build-release.yml/badge.svg)](https://github.com/Luis-Rosario-Alers/CarbonCalculator/actions/workflows/python-build-release.yml)
 
 [Getting Started👋](docs/GETTING_STARTED.md) | [FAQ❓](FAQ.md)| [Contributing🤝](CONTRIBUTING)
 


### PR DESCRIPTION
Related to #39

Add a badge for the build and release workflow to `README.md`.

Update `.github/workflows/python-build-release.yml`:
* Remove `continue-on-error: true` from the build step.
* Add a step to check for successful build completion before proceeding to the release step.
* Ensure artifact names match the expected pattern in the release step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Luis-Rosario-Alers/CarbonCalculator/pull/40?shareId=42bb65db-98fc-43f0-af5d-243877186673).